### PR TITLE
Add www to TLD frontend rules

### DIFF
--- a/apps/_core.yml
+++ b/apps/_core.yml
@@ -92,7 +92,7 @@
 
 - name: 'If Fact Matches - Enable TLD'
   set_fact:
-    tldset: '{{domain.stdout}}'
+    tldset: '{{domain.stdout}},www.{{domain.stdout}}'
   when: 'toplevel.stdout == pgrole'
 
 - debug: msg="TLDSET is now for {{toplevel.stdout}}"


### PR DESCRIPTION
Prevents a 404 error when trying to hit www.domain.com. I was unable to resolve this with either DNS wizardry nor modifying traefik.toml for redirects.