### PR TITLE
Move to new nzbhydra image

### DIFF
--- a/apps/nzbhydra.yml
+++ b/apps/nzbhydra.yml
@@ -15,7 +15,7 @@
         pgrole: 'nzbhydra'
         intport: '5076'
         extport: '5076'
-        image: 'linuxserver/hydra2'
+        image: 'linuxserver/nzbhydra2'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
linuxserver/hydra2 is depracted, new image is linuxserver/nzbhydra2

https://docs.linuxserver.io/images/docker-hydra2