### PR TITLE
Change repository due to docker rate limitations

### DIFF
--- a/apps/image/nzbget
+++ b/apps/image/nzbget
@@ -1,2 +1,2 @@
-linuxserver/nzbget
-linuxserver/nzbget:testing
+ghcr.io/linuxserver/nzbget
+ghcr.io/linuxserver/nzbget:testing

--- a/apps/image/ombi
+++ b/apps/image/ombi
@@ -1,2 +1,2 @@
-linuxserver/ombi
-linuxserver/ombi:v4-preview
+ghcr.io/linuxserver/ombi
+ghcr.io/linuxserver/ombi:v4-preview

--- a/apps/image/radarr
+++ b/apps/image/radarr
@@ -1,3 +1,3 @@
-linuxserver/radarr
-linuxserver/radarr:preview
+ghcr.io/linuxserver/radarr
+ghcr.io/linuxserver/radarr:preview
 aront/radarr

--- a/apps/image/rutorrent
+++ b/apps/image/rutorrent
@@ -1,3 +1,3 @@
-linuxserver/rutorrent:v3.9-ls45
-linuxserver/rutorrent
+ghcr.io/linuxserver/rutorrent:v3.9-ls45
+ghcr.io/linuxserver/rutorrent
 horjulf/rutorrent-autodl

--- a/apps/image/sonarr
+++ b/apps/image/sonarr
@@ -1,3 +1,3 @@
-linuxserver/sonarr:preview
-linuxserver/sonarr
+ghcr.io/linuxserver/sonarr:preview
+ghcr.io/linuxserver/sonarr
 aront/sonarr

--- a/apps/jackett.yml
+++ b/apps/jackett.yml
@@ -15,7 +15,7 @@
         pgrole: 'jackett'
         intport: '9117'
         extport: '9117'
-        image: 'linuxserver/jackett'
+        image: 'ghcr.io/linuxserver/jackett'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/lazylibrarian.yml
+++ b/apps/lazylibrarian.yml
@@ -15,7 +15,7 @@
         pgrole: 'lazylibrarian'
         intport: '5299'
         extport: '5299'
-        image: 'linuxserver/lazylibrarian'
+        image: 'ghcr.io/linuxserver/lazylibrarian'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/lidarr.yml
+++ b/apps/lidarr.yml
@@ -15,7 +15,7 @@
         pgrole: 'lidarr'
         intport: '8686'
         extport: '8686'
-        image: 'linuxserver/lidarr'
+        image: 'ghcr.io/linuxserver/lidarr'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/nzbget.yml
+++ b/apps/nzbget.yml
@@ -16,7 +16,7 @@
         pgrole: 'nzbget'
         intport: '6789'
         extport: '6789'
-        image: 'linuxserver/nzbget'
+        image: 'ghcr.io/linuxserver/nzbget'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/nzbhydra.yml
+++ b/apps/nzbhydra.yml
@@ -15,7 +15,7 @@
         pgrole: 'nzbhydra'
         intport: '5076'
         extport: '5076'
-        image: 'linuxserver/nzbhydra2'
+        image: 'ghcr.io/linuxserver/nzbhydra2'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/ombi.yml
+++ b/apps/ombi.yml
@@ -16,7 +16,7 @@
         pgrole: 'ombi'
         intport: '3579'
         extport: '3579'
-        image: 'linuxserver/ombi'
+        image: 'ghcr.io/linuxserver/ombi'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/qbittorrent.yml
+++ b/apps/qbittorrent.yml
@@ -18,7 +18,7 @@
         extport: '8083'
         intport2: '7889'
         extport2: '7889'
-        image: 'linuxserver/qbittorrent'
+        image: 'ghcr.io/linuxserver/qbittorrent'
 
     # CORE (MANDATORY) #############################################################
     - name: 'Including cron job'

--- a/apps/radarr.yml
+++ b/apps/radarr.yml
@@ -16,7 +16,7 @@
         pgrole: 'radarr'
         intport: '7878'
         extport: '7878'
-        image: 'linuxserver/radarr:preview'
+        image: 'ghcr.io/linuxserver/radarr:preview'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/rutorrent.yml
+++ b/apps/rutorrent.yml
@@ -19,7 +19,7 @@
         extport2: '5000'
         intport3: '51413'
         extport3: '51413'
-        image: 'linuxserver/rutorrent'
+        image: 'ghcr.io/linuxserver/rutorrent'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/sabnzbd.yml
+++ b/apps/sabnzbd.yml
@@ -16,7 +16,7 @@
         pgrole: 'sabnzbd'
         intport: '8080'
         extport: '8080'
-        image: 'linuxserver/sabnzbd'
+        image: 'ghcr.io/linuxserver/sabnzbd'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/sonarr.yml
+++ b/apps/sonarr.yml
@@ -16,7 +16,7 @@
         pgrole: 'sonarr'
         intport: '8989'
         extport: '8989'
-        image: 'linuxserver/sonarr:preview'
+        image: 'ghcr.io/linuxserver/sonarr:preview'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'

--- a/apps/tautulli.yml
+++ b/apps/tautulli.yml
@@ -15,7 +15,7 @@
         pgrole: 'tautulli'
         intport: '8181'
         extport: '8181'
-        image: 'linuxserver/tautulli'
+        image: 'ghcr.io/linuxserver/tautulli'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
Changed linuxserver.io repository to the ghcr.io prefix per the linuxserver.io team due to the rate limits now being imposed by docker.com